### PR TITLE
Add iconification support and fix message handling  #27

### DIFF
--- a/assets/aminet/TuneFinder.README
+++ b/assets/aminet/TuneFinder.README
@@ -123,6 +123,7 @@ TuneFinder 1.3 (30.11.2024)
 - Users can now select a program (AmigaAMP) to launch together with TuneFinder
 - Added favorites management system
 - Added Favorites menu item under Project menu
+- Add iconification support
 - Added functionality to save country and codec on exit
 - Added Fav+ and Fav- buttons for adding/removing favorites
 - Stations can be saved to and loaded from favorites list

--- a/assets/translation/tunefinder.cd
+++ b/assets/translation/tunefinder.cd
@@ -76,6 +76,12 @@ About...
 MSG_SEARCHING (26//)
 Searching
 ;
+MSG_FAVORITES (27//)
+Favorites
+;
+MSG_ICONIFY (28//)
+Iconify
+;
 ; Options and Settings
 MSG_HOST (30//)
 API Host

--- a/assets/translation/tunefinder_english.ct
+++ b/assets/translation/tunefinder_english.ct
@@ -77,6 +77,9 @@ Searching
 MSG_FAVORITES
 Favorites
 ;
+MSG_ICONIFY
+Iconify
+;
 MSG_HOST
 API Host
 ;

--- a/include/gui.h
+++ b/include/gui.h
@@ -20,9 +20,18 @@ extern struct CountryConfig countryConfig;
 extern BOOL running;  // Add this line
 extern void *visualInfo;
 
+extern struct AppIcon *appIcon;
+extern struct MsgPort *appPort;
+extern WORD savedLeftEdge;
+extern WORD savedTopEdge;
+extern struct Image IconImage;
+extern struct DiskObject TuneFinderIcon;
+
 BOOL InitLibraries(void);
 void CleanupLibraries(void);
 BOOL OpenGUI(void);
+BOOL IconifyWindow(void);
+BOOL UnIconifyWindow(void);
 void CleanupGUI(void);
 struct List* CreateInitialList(void);
 static struct Menu *CreateAppMenus(void);

--- a/include/locale.h
+++ b/include/locale.h
@@ -34,6 +34,8 @@
 #define MSG_ABOUT             25
 #define MSG_SEARCHING         26
 #define MSG_FAVORITES         27
+#define MSG_ICONIFY           28
+
 // Options and Settings
 #define MSG_HOST              30
 #define MSG_PORT              31

--- a/src/locale/locale.c
+++ b/src/locale/locale.c
@@ -17,7 +17,7 @@ static struct Catalog *Catalog = NULL;
 // locale.c
 static const char *built_in_strings[] = {
     // GUI Labels (1-6)
-    "Name", "Country", "Codec", "Tags", "Bitrate", "Unknown", "Limit", "URL",
+    "Name", "Country", "Codec", "Tags", "Bitrate", "Unknown", "Limit", "URL", 
     // Padding to align with IDs 9
     NULL,
 
@@ -28,9 +28,9 @@ static const char *built_in_strings[] = {
 
     // GUI States (20-25)
     "Ready", "Settings...", "API Settings", "Station Details", "Project",
-    "About...", "Searching", "Favorites",
-    // Padding to align with IDs 28-29
-    NULL, NULL,
+    "About...", "Searching", "Favorites", "Iconify",
+    // Padding to align with IDs 29
+    NULL,
 
     // Options and Settings (30-35)
     "API Host", "API Port", "HTTPS Only", "Hide Broken", "Autostart Program", "Browse",


### PR DESCRIPTION
- Add ability to iconify application via 'I' key or menu
- Implement AppIcon creation and management using Workbench icon
- Add proper message port cleanup and error handling 
- Add safety checks for null pointers and message flushing
- Separate message processing from state changes

The application can now be minimized to a Workbench icon and restored 
by double-clicking.  