### PR TITLE
Add window position persistence

### DIFF
--- a/assets/aminet/TuneFinder.README
+++ b/assets/aminet/TuneFinder.README
@@ -123,8 +123,9 @@ TuneFinder 1.3 (30.11.2024)
 - Users can now select a program (AmigaAMP) to launch together with TuneFinder
 - Added favorites management system
 - Added Favorites menu item under Project menu
-- Add iconification support
-- Add list content preservation during iconification
+- Added iconification support
+- Added list content preservation during iconification
+- Added window position persistence
 - Added functionality to save country and codec on exit
 - Added Fav+ and Fav- buttons for adding/removing favorites
 - Stations can be saved to and loaded from favorites list

--- a/include/config.h
+++ b/include/config.h
@@ -25,6 +25,7 @@
 #define PLS_LENGTH_ENTRY "Length%d=-1\n"
 #define DEFAULT_PLS_FILENAME "radio.pls"
 #define MAX_STATION_NAME 40
+#define NO_POSITION 0xFFFFFFFF
 
 #ifdef DEBUG_BUILD
     #define DEBUG(msg, ...) printf("DEBUG [%s:%d]: " msg "\n", __func__, __LINE__, ##__VA_ARGS__)

--- a/include/settings.h
+++ b/include/settings.h
@@ -24,6 +24,9 @@ struct APISettings {
     int port;
     int limit;
     char autostart[MAX_PATH_LEN];
+    ULONG windowLeft;
+    ULONG windowTop;
+
 };
 
 BOOL LoadSettings(struct APISettings *settings);


### PR DESCRIPTION
- Save window position on exit
- Load and restore last window position on startup
- Center window by default when no position is stored
- Add bounds checking to ensure window stays on screen