### PR TITLE
Add missing locale strings and complete catalog description #32

### DIFF
--- a/assets/aminet/TuneFinder.README
+++ b/assets/aminet/TuneFinder.README
@@ -126,7 +126,7 @@ TuneFinder 1.3 (30.11.2024)
 - Added iconification support
 - Added list content preservation during iconification
 - Added window position persistence
-- Added functionality to save country and codec on exit
+- Added functionality to save last used country and codec on exit
 - Added Fav+ and Fav- buttons for adding/removing favorites
 - Stations can be saved to and loaded from favorites list
 - Renamed Save buttons to 'All' and 'One' for better fit

--- a/assets/translation/deutsch/tunefinder.ct
+++ b/assets/translation/deutsch/tunefinder.ct
@@ -1,6 +1,6 @@
 ; tunefinder_german.ct
 ; Catalog description for TuneFinder
-; $VER: tunefinder.cd 1.0 (14.11.2024)
+; $VER: tunefinder.cd 1.0 (07.12.2024)
 ## version $VER: Tunefinder.catalog 1.0
 ## Codeset 0
 ## language deutsch
@@ -51,12 +51,18 @@ Einzeln Sichern
 MSG_STOP
 Gestoppt
 ;
+MSG_FAVORITE
+Fav+
+;
+MSG_UNFAVORITE
+Fav-
+;
 ; GUI States
 MSG_READY
 Bereit
 ;
 MSG_SETTINGS
-Einstellungen
+Einstellungen...
 ;
 MSG_API_SETTINGS
 API Einstellungen
@@ -68,10 +74,16 @@ MSG_PROJECT
 Projekt
 ;
 MSG_ABOUT
-Über
+Über...
 ;
 MSG_SEARCHING
-Suche
+Suchen
+;
+MSG_FAVORITES
+Favoriten
+;
+MSG_ICONIFY
+Ikonifizieren
 ;
 ; Options and Settings
 MSG_HOST
@@ -84,7 +96,7 @@ MSG_HTTPS_ONLY
 Nur HTTPS
 ;
 MSG_HIDE_BROKEN
-Verberge unvollständige Sender
+Verberge unvollständige
 ;
 ; Status Messages with Parameters
 MSG_FOUND_STATIONS
@@ -106,10 +118,16 @@ MSG_FILE_SAVED
 Datei gespeichert: %s
 ;
 MSG_SET_SAVED
-Einstellungen gespeichert: %s:%u Limit:%u
+Einstellungen gespeichert: %s:%u 
 ;
-MSG_NO_STATIONS
+MSG_NO_STATIONS_FOUND
 Keine Stationen gefunden
+;
+MSG_FAVORITE_ADDED
+Favoriten hinzufügen
+;
+MSG_FAVORITE_REMOVED
+Sender von Favoriten entfernt
 ;
 ; Error Messages - Settings Related
 MSG_INVALID_PORT
@@ -121,11 +139,17 @@ Schreiben der Porteinstellung fehlgeschlagen
 MSG_FAILED_WRITE_HOST_SETTING
 Schreiben der Hosteinstellumgen fehlgeschlagen
 ;
-MSG_INVALID_LOCALE
-Ungültiger lokaler Wert, behalte Aktuellen: %ld
+MSG_INVALID_LIMIT
+Ungültiger Grenzwert, behalte Aktuellen: %ld
 ;
 MSG_FAILED_WRITE_LIMIT_SET
 Schreiben der eingeschränkten Einstellungen fehlgeschlagen
+;
+MSG_FAILED_ADD_FAVORITE
+Favoriten hinzufügen fehlgeschlagen
+;
+MSG_FAILED_REMOVE_FAVORITE
+Favoriten entfernen fehlgeschlagen
 ;
 ; Error Messages - File Operations
 MSG_FAILED_FILE_SAVE

--- a/assets/translation/tunefinder.cd
+++ b/assets/translation/tunefinder.cd
@@ -95,6 +95,15 @@ HTTPS Only
 MSG_HIDE_BROKEN (33//)
 Hide Broken
 ;
+MSG_AUTOSTART (34//)
+Autostart Program
+;
+MSG_BROWSE (35//)
+Browse
+;
+MSG_SELECT_PROGRAM (36//)
+Select program
+;
 ; Status Messages with Parameters
 MSG_FOUND_STATIONS (40//)
 Found %d stations
@@ -163,6 +172,12 @@ Failed to create host settings file: %s
 ;
 MSG_FAILED_CREAT_LIMIT_FILE (64//)
 Failed to create limit settings file: %s
+;
+MSG_FAILED_CREAT_AUTO_FILE (65//)
+Failed to create autostart settings file: %s
+;
+MSG_FAILED_WRITE_AUTO_SET (66//)
+Failed to write autostart setting
 ;
 ; Error Messages - Directory Operations
 MSG_CREATED_SET_DIR (70//)

--- a/assets/translation/tunefinder_english.ct
+++ b/assets/translation/tunefinder_english.ct
@@ -92,6 +92,16 @@ HTTPS Only
 MSG_HIDE_BROKEN
 Hide Broken
 ;
+MSG_AUTOSTART
+Autostart Program
+;
+MSG_BROWSE
+Browse
+;
+MSG_SELECT_PROGRAM
+Select program
+;
+
 MSG_FOUND_STATIONS
 Found %d stations
 ;
@@ -157,6 +167,12 @@ Failed to create host settings file: %s
 ;
 MSG_FAILED_CREAT_LIMIT_FILE
 Failed to create limit settings file: %s
+;
+MSG_FAILED_CREAT_AUTO_FILE
+Failed to create autostart settings file: %s
+;
+MSG_FAILED_WRITE_AUTO_SET
+Failed to write autostart setting
 ;
 MSG_CREATED_SET_DIR
 Created settings directory: %s

--- a/include/locale.h
+++ b/include/locale.h
@@ -43,6 +43,7 @@
 #define MSG_HIDE_BROKEN       33
 #define MSG_AUTOSTART         34  // "Autostart Program"
 #define MSG_BROWSE            35  // "Browse"
+#define MSG_SELECT_PROGRAM    36  // "Select program"
 
 // Status Messages with Parameters
 #define MSG_FOUND_STATIONS     40  // "Found %d stations"

--- a/include/version.h
+++ b/include/version.h
@@ -1,9 +1,9 @@
 #ifndef VERSION_H
 #define VERSION_H
 
-#define VERS "TuneFinder 1.3-beta"
-#define VSTRING "TuneFinder  1.3-beta (12.06.2024)\r\n"
-#define VERSTAG "\0$VER: TuneFinder  1.3-beta (12.06.2024)"
+#define VERS "TuneFinder 1.3-beta3"
+#define VSTRING "TuneFinder  1.3-beta3 (12.07.2024)\r\n"
+#define VERSTAG "\0$VER: TuneFinder  1.3-beta3 (12.07.2024)"
 #define AUTHOR "Marcin Spoczynski"
 #define TRANSLATION "-German: Thomas Blatt\n-Italian: Samir Hawamdeh\n Icons: Thomas Blatt\n"
 __attribute__((section(".text"))) UBYTE VString[] =

--- a/src/gui/gui.c
+++ b/src/gui/gui.c
@@ -43,8 +43,8 @@ extern void geta4(void);
 #endif
 // Menu Constants
 #define MENU_PROJECT 0   // Menu number for Project menu
-#define ITEM_SETTINGS 1  // for Settings
-#define ITEM_FAVORITES 2 // For Favorites
+#define ITEM_SETTINGS 0  // for Settings
+#define ITEM_FAVORITES 1 // For Favorites
 #define ITEM_ICONIFY 3   // for Iconify
 #define ITEM_ABOUT 4     // for About
 #define ITEM_QUIT 5      // for Quit (after separator)

--- a/src/gui/gui.c
+++ b/src/gui/gui.c
@@ -109,9 +109,9 @@ static struct Menu *CreateAppMenus(void) {
       {NM_TITLE, GetTFString(MSG_PROJECT), NULL, 0, 0L, NULL},
       {NM_ITEM, GetTFString(MSG_SETTINGS), "S", 0, 0L, NULL},
       {NM_ITEM, GetTFString(MSG_FAVORITES), "F", 0, 0L, NULL},
-      {NM_ITEM, GetTFString(MSG_ABOUT), "?", 0, 0L, NULL},
       {NM_ITEM, NM_BARLABEL, NULL, 0, 0L, NULL},
       {NM_ITEM, GetTFString(MSG_ICONIFY), "I", 0, 0L, NULL},
+      {NM_ITEM, GetTFString(MSG_ABOUT), "?", 0, 0L, NULL},
       {NM_ITEM, GetTFString(MSG_QUIT), "Q", 0, 0L, NULL},
       {NM_END, NULL, NULL, 0, 0L, NULL}};
 
@@ -1068,7 +1068,7 @@ BOOL OpenGUI(void) {
 
   ng.ng_LeftEdge += ng.ng_Width + font_width * 2;
   ng.ng_Width = smallWidth;
-  ng.ng_GadgetText = "Fav+";
+  ng.ng_GadgetText = GetTFString(MSG_FAVORITE_ADDED);
   ng.ng_GadgetID = 17;
   favoriteButton =
       CreateGadget(BUTTON_KIND, saveSingleButton, &ng,GT_Underscore, '_', TAG_DONE);
@@ -1076,7 +1076,7 @@ BOOL OpenGUI(void) {
   // Unfavorite button
 
   ng.ng_LeftEdge += ng.ng_Width + font_width *2;
-  ng.ng_GadgetText = "Fav-";
+  ng.ng_GadgetText = GetTFString(MSG_FAVORITE_REMOVED);
   ng.ng_GadgetID = 18;
   unfavoriteButton =
       CreateGadget(BUTTON_KIND, favoriteButton, &ng, GT_Underscore, '_', GA_Disabled, TRUE, TAG_DONE);
@@ -1202,6 +1202,16 @@ cleanup:
 }
 BOOL IconifyWindow(void) {
   if (!window) return FALSE;
+    LONG country = 0, codec = 0;
+    GT_GetGadgetAttrs(countryCodeCycle, window, NULL,
+                      GTCY_Active, &country,
+                      TAG_DONE);
+    GT_GetGadgetAttrs(codecCycle, window, NULL,
+                      GTCY_Active, &codec,
+                      TAG_DONE);
+                      
+    SaveCyclePreferences(country, codec);
+    DEBUG("Saved cycle states - Country: %ld, Codec: %ld", country, codec);
 
   // Create message port for AppIcon if not already created
   if (!appPort) {

--- a/src/gui/gui.c
+++ b/src/gui/gui.c
@@ -666,7 +666,7 @@ void HandleMenuPick(UWORD menuNumber) {
               "\n\n"
               "Created by " AUTHOR
               "\n"
-              "An Internet radio browser for AmigaOS 3.x\n\n"
+              "An Internet radio browser for Amiga 68k\n\n"
               "Translations:\n" TRANSLATION,
               "OK"};
           EasyRequest(window, &es, NULL, NULL);

--- a/src/gui/gui.c
+++ b/src/gui/gui.c
@@ -43,11 +43,11 @@ extern void geta4(void);
 #endif
 // Menu Constants
 #define MENU_PROJECT 0   // Menu number for Project menu
-#define ITEM_SETTINGS 0  // for Settings
-#define ITEM_FAVORITES 1 // For Favortes
-#define ITEM_ABOUT 2     // for About
-#define ITEM_ICONIFY 4      // for iconify  (after separator)
-#define ITEM_QUIT 5      // for Quit  
+#define ITEM_SETTINGS 1  // for Settings
+#define ITEM_FAVORITES 2 // For Favorites
+#define ITEM_ICONIFY 3   // for Iconify
+#define ITEM_ABOUT 4     // for About
+#define ITEM_QUIT 5      // for Quit (after separator)
 
 // Library Handles
 //struct Library *IntuitionBase = NULL;
@@ -1068,7 +1068,7 @@ BOOL OpenGUI(void) {
 
   ng.ng_LeftEdge += ng.ng_Width + font_width * 2;
   ng.ng_Width = smallWidth;
-  ng.ng_GadgetText = GetTFString(MSG_FAVORITE_ADDED);
+  ng.ng_GadgetText = GetTFString(MSG_FAVORITE);
   ng.ng_GadgetID = 17;
   favoriteButton =
       CreateGadget(BUTTON_KIND, saveSingleButton, &ng,GT_Underscore, '_', TAG_DONE);
@@ -1076,7 +1076,7 @@ BOOL OpenGUI(void) {
   // Unfavorite button
 
   ng.ng_LeftEdge += ng.ng_Width + font_width *2;
-  ng.ng_GadgetText = GetTFString(MSG_FAVORITE_REMOVED);
+  ng.ng_GadgetText = GetTFString(MSG_UNFAVORITE);
   ng.ng_GadgetID = 18;
   unfavoriteButton =
       CreateGadget(BUTTON_KIND, favoriteButton, &ng, GT_Underscore, '_', GA_Disabled, TRUE, TAG_DONE);

--- a/src/locale/locale.c
+++ b/src/locale/locale.c
@@ -22,9 +22,9 @@ static const char *built_in_strings[] = {
     NULL,
 
     // GUI Actions (10-14)
-    "Search", "Save All", "Cancel", "Play", "Quit", "Save One", "Stop",
+    "Search", "Save All", "Cancel", "Play", "Quit", "Save One", "Stop", "Fav+", "Fav-",
     // Padding to align with IDs 17-19
-    NULL, NULL, NULL,
+    NULL,
 
     // GUI States (20-25)
     "Ready", "Settings...", "API Settings", "Station Details", "Project",

--- a/src/locale/locale.c
+++ b/src/locale/locale.c
@@ -34,9 +34,9 @@ static const char *built_in_strings[] = {
 
     // Options and Settings (30-35)
     "API Host", "API Port", "HTTPS Only", "Hide Broken", "Autostart Program", "Browse",
-
-    // Padding to align with IDs 36-39
-    NULL, NULL, NULL, NULL,
+    "Select Program",
+    // Padding to align with IDs 39
+    NULL, NULL, NULL, 
 
     // Status Messages with Parameters (40-46)
     "Found %d stations", "Playing: %s", "Settings loaded.", "Settings saved.",

--- a/src/settings/settings.c
+++ b/src/settings/settings.c
@@ -271,9 +271,9 @@ BOOL CreateSettingsWindow(struct APISettings *settings, struct Window *parent) {
   WORD topMargin = border_height + font_height;  // Top margin
   WORD rowHeight = font_height + 6;              // Height of each row
   WORD rowSpacing = font_height / 2;             // Space between rows
-  WORD labelWidth = font_width * 10;             // Width for labels
-  WORD controlWidth = font_width * 25;           // Width for input fields
-  WORD buttonWidth = font_width * 10;            // Width for buttons
+  WORD labelWidth = font_width * 20;             // Width for labels
+  WORD controlWidth = font_width * 30;           // Width for input fields
+  WORD buttonWidth = font_width * 12;            // Width for buttons
   WORD windowWidth = leftMargin * 3 + controlWidth + labelWidth;
 
   // Create gadget context
@@ -402,10 +402,15 @@ BOOL CreateSettingsWindow(struct APISettings *settings, struct Window *parent) {
   // Center window relative to parent
   WORD windowLeft = parent->LeftEdge + (parent->Width - windowWidth) / 2;
   WORD windowTop = parent->TopEdge + (parent->Height - windowHeight) / 2;
-
+  
+  char settingsText[32];  
+  const char *fullText = GetTFString(MSG_SETTINGS);
+  strncpy(settingsText, fullText, strlen(fullText) - 3);
+  settingsText[strlen(fullText) - 3] = '\0';  
+  
   // Create window
   window =
-      OpenWindowTags(NULL, WA_Title, GetTFString(MSG_SETTINGS), WA_Left,
+      OpenWindowTags(NULL, WA_Title, settingsText, WA_Left,
                      windowLeft, WA_Top, windowTop, WA_Width, windowWidth,
                      WA_Height, windowHeight, WA_IDCMP,
                      IDCMP_CLOSEWINDOW | IDCMP_GADGETUP | IDCMP_REFRESHWINDOW |
@@ -511,7 +516,7 @@ BOOL CreateSettingsWindow(struct APISettings *settings, struct Window *parent) {
               if (fileReq) {
                 if (AslRequestTags(
                         fileReq, ASLFR_Window, window, ASLFR_TitleText,
-                        "Select Program", ASLFR_InitialDrawer,
+                        GetTFString(MSG_SELECT_PROGRAM), ASLFR_InitialDrawer,
                         "SYS:", ASLFR_DrawersOnly, FALSE, ASLFR_DoPatterns,
                         TRUE, ASLFR_InitialPattern, "#?", TAG_DONE)) {
                   char filepath[256];


### PR DESCRIPTION
- Add autostart program strings for settings window
- Add error messages for autostart configuration
- Add browse and select program UI strings
- Update catalog description file to match locale.h
- Fix missing error messages for autostart settings
- Increase settings window width for longer text fields
- Adjust label and control widths for better readability
